### PR TITLE
matplotlib-venn 0.11.10

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+upload_channels:
+  - sfe1ed40

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,31 +1,43 @@
-{% set version = "0.11.7" %}
+{% set version = "0.11.10" %}
 
 package:
   name: matplotlib-venn
   version: {{ version }}
 
 source:
-  url: https://pypi.org/packages/source/m/matplotlib-venn/matplotlib-venn-{{ version }}.tar.gz
-  sha256: 8d8b3505594313099328c9f177133dd800a28f3dd68e6800a78250c0cccce317
+  #url: https://pypi.org/packages/source/m/matplotlib-venn/matplotlib-venn-{{ version }}.tar.gz
+  url: https://github.com/konstantint/matplotlib-venn/archive/refs/tags/{{ version }}.tar.gz
+  sha256: acb254f6fc0c8eb4e49df6655b316903d6babe2e9c0049636c2426a3a861cfbc
 
 build:
   number: 0
   noarch: python
   script: {{ PYTHON }} -m pip install . --no-deps -vv
+  skip: True  # [py<36]
 
 requirements:
   host:
-    - python >=3.6
+    - python
     - pip
+    - setuptools
+    - wheel
   run:
-    - python >=3.6
+    - python
     - matplotlib-base
     - numpy
     - scipy
 
 test:
+  source_files:
+    - tests
   imports:
     - matplotlib_venn
+  commands:
+    - pip check
+    - pytest -v .
+  requires:
+    - pip
+    - pytest
 
 about:
   home: https://github.com/konstantint/matplotlib-venn
@@ -33,7 +45,10 @@ about:
   license_file: LICENSE
   license_family: MIT
   summary: Functions for plotting area-proportional two- and three-way Venn diagrams in matplotlib.
+  description: |
+    Routines for plotting area-weighted two- and three-circle venn diagrams.
   dev_url: https://github.com/konstantint/matplotlib-venn
+  doc_url: https://github.com/konstantint/matplotlib-venn/blob/master/README.rst
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -5,7 +5,6 @@ package:
   version: {{ version }}
 
 source:
-  #url: https://pypi.org/packages/source/m/matplotlib-venn/matplotlib-venn-{{ version }}.tar.gz
   url: https://github.com/konstantint/matplotlib-venn/archive/refs/tags/{{ version }}.tar.gz
   sha256: acb254f6fc0c8eb4e49df6655b316903d6babe2e9c0049636c2426a3a861cfbc
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   number: 0
   noarch: python
-  script: {{ PYTHON }} -m pip install . --no-deps -vv
+  script: {{ PYTHON }} -m pip install . --no-deps -vv --no-deps --no-build-isolation
   skip: True  # [py<36]
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,8 +32,8 @@ test:
     - matplotlib_venn
   commands:
     - pip check
-    - pytest -v . -k "not test_circle_region" # [py38]
-    - pytest -v .                             # [not py38]
+    - pytest -v . -k "not test_circle_region" # [py==38]
+    - pytest -v .                             # [not py==38]
   requires:
     - pip
     - pytest

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,7 +32,8 @@ test:
     - matplotlib_venn
   commands:
     - pip check
-    - pytest -v . -k "not test_circle_region"
+    - pytest -v . -k "not test_circle_region" # [py38]
+    - pytest -v .                             # [not py38]
   requires:
     - pip
     - pytest

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,7 +32,8 @@ test:
     - matplotlib_venn
   commands:
     - pip check
-    - pytest -v .
+    - pytest -v . -k "test_circle_region"   # [py38]
+    - pytest -v .                           # [not py38]
   requires:
     - pip
     - pytest

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,8 +32,7 @@ test:
     - matplotlib_venn
   commands:
     - pip check
-    - pytest -v . -k "test_circle_region"   # [py38]
-    - pytest -v .                           # [not py38]
+    - pytest -v . -k "test_circle_region"
   requires:
     - pip
     - pytest

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,8 +10,7 @@ source:
 
 build:
   number: 0
-  noarch: python
-  script: {{ PYTHON }} -m pip install . --no-deps -vv --no-deps --no-build-isolation
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
   skip: True  # [py<36]
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,7 +32,7 @@ test:
     - matplotlib_venn
   commands:
     - pip check
-    - pytest -v . -k "test_circle_region"
+    - pytest -v . -k "not test_circle_region"
   requires:
     - pip
     - pytest

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -46,7 +46,7 @@ about:
   description: |
     Routines for plotting area-weighted two- and three-circle venn diagrams.
   dev_url: https://github.com/konstantint/matplotlib-venn
-  doc_url: https://github.com/konstantint/matplotlib-venn/blob/master/README.rst
+  doc_url: https://github.com/konstantint/matplotlib-venn
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
matplotlib-venn 0.11.10 :snowflake:

**Destination channel:** Snowflake 

### Links

- [PKG-5100](https://anaconda.atlassian.net/browse/PKG-5100) 
- [Upstream repository](https://github.com/konstantint/matplotlib-venn/tree/0.11.10)
- [Upstream changelog/diff](https://github.com/konstantint/matplotlib-venn/compare/0.11.7...0.11.10)

### Explanation of changes:

- build for 0.11.10
- changing source in order to include tests
- removing test for py38. See thread for details


[PKG-5100]: https://anaconda.atlassian.net/browse/PKG-5100?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ