### PR TITLE
matplotlib-venn 1.1.2

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-upload_channels:
-  - sfe1ed40

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,7 @@ requirements:
   host:
     - python
     - pip
-    - setuptools
+    - setuptools >=70.0.1
   run:
     - python
     - matplotlib-base

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,3 +1,4 @@
+{% set name = "matplotlib-venn" %}
 {% set version = "1.1.2" %}
 
 package:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,29 +1,30 @@
-{% set version = "0.11.10" %}
+{% set version = "1.1.2" %}
 
 package:
   name: matplotlib-venn
   version: {{ version }}
 
 source:
-  url: https://github.com/konstantint/matplotlib-venn/archive/refs/tags/{{ version }}.tar.gz
-  sha256: acb254f6fc0c8eb4e49df6655b316903d6babe2e9c0049636c2426a3a861cfbc
+  url: https://pypi.org/packages/source/m/matplotlib-venn/matplotlib-venn-{{ version }}.tar.gz
+  sha256: 6f2b07a03e9bb5a62de2f32f965216739e175176f9d654dd19e7af2c22ec36e3
 
 build:
   number: 0
-  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
-  skip: True  # [py<36]
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
+  skip: true  # [py<39]
 
 requirements:
   host:
     - python
     - pip
     - setuptools
-    - wheel
   run:
     - python
     - matplotlib-base
     - numpy
     - scipy
+  run_constrained:
+    - shapely
 
 test:
   source_files:
@@ -32,8 +33,7 @@ test:
     - matplotlib_venn
   commands:
     - pip check
-    - pytest -v . -k "not test_circle_region" # [py==38]
-    - pytest -v .                             # [not py==38]
+    - pytest -v tests/
   requires:
     - pip
     - pytest
@@ -52,3 +52,4 @@ about:
 extra:
   recipe-maintainers:
     - pmlandwehr
+    - ocefpaf

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -5,8 +5,8 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.org/packages/source/m/matplotlib-venn/matplotlib-venn-{{ version }}.tar.gz
-  sha256: 6f2b07a03e9bb5a62de2f32f965216739e175176f9d654dd19e7af2c22ec36e3
+  url: https://github.com/konstantint/matplotlib-venn/archive/refs/tags/{{ version }}.tar.gz
+  sha256: 6111d8463101e1fe1c567a12d0fa8fff4315ce9acddcbbc5f0915d85d49cb019
 
 build:
   number: 0
@@ -33,7 +33,7 @@ test:
     - matplotlib_venn
   commands:
     - pip check
-    - pytest -v tests/
+    - pytest -v .
   requires:
     - pip
     - pytest

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -2,7 +2,7 @@
 {% set version = "1.1.2" %}
 
 package:
-  name: matplotlib-venn
+  name: {{ name }}
   version: {{ version }}
 
 source:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,7 +6,7 @@ package:
   version: {{ version }}
 
 source:
-  url: https://github.com/konstantint/matplotlib-venn/archive/refs/tags/{{ version }}.tar.gz
+  url: https://github.com/konstantint/{{ name }}/archive/refs/tags/{{ version }}.tar.gz
   sha256: 6111d8463101e1fe1c567a12d0fa8fff4315ce9acddcbbc5f0915d85d49cb019
 
 build:


### PR DESCRIPTION
matplotlib-venn 1.1.2

**Destination channel:** defaults

### Links

- [PKG-12987](https://anaconda.atlassian.net/browse/PKG-12987)
- [Upstream repository](https://github.com/konstantint/matplotlib-venn)
- [Upstream changelog](https://github.com/konstantint/matplotlib-venn/blob/1.1.2/CHANGELOG.txt)

### Explanation of changes:

- Updated matplotlib-venn from 0.11.10 to 1.1.2
- Switched source URL from GitHub archive to PyPI sdist
- Removed `wheel` from host (not needed by setuptools backend)
- Removed `abs.yaml` (pure Python, no special PBP config needed)
- Updated skip selector from `py<36` to `py<39`
- Removed py38-specific test skip (no longer relevant)
- Added `run_constrained: shapely` for optional `shapely` extra (cost-based layout algorithm added in v1.1.0)
- Added `ocefpaf` to recipe-maintainers (from conda-forge)
- Simplified pytest command to `pytest -v tests/`

[PKG-12987]: https://anaconda.atlassian.net/browse/PKG-12987?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ